### PR TITLE
User story 25.1

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -3,4 +3,8 @@ class Admin::MerchantsController < ApplicationController
   def index
     @merchants = Merchant.all
   end
+
+  def show
+    @merchant = Merchant.find(params[:id])
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,5 @@
 <div class="page-title">Admin Merchants Index</div> 
 
 <% @merchants.each do |merchant| %>
-<%= merchant.name %>
+<%= link_to merchant.name, admin_merchant_path(merchant) %>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,3 @@
+<div class="page-title">Admin Merchants Show</div> 
+
+<%= @merchant.name %>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe "Admin Merchants Index Page" do
     expect(page).to have_content(@merchant_6.name)
     expect(page).to_not have_content("Johnson-Dickinson")
   end
+
+  it "links to the merchant show page when you click the merchant's name" do
+    visit "/admin/merchants"
+
+    click_link(@merchant_1.name)
+    expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
+
+    visit "/admin/merchants"
+    
+    click_link(@merchant_2.name)
+    expect(current_path).to eq("/admin/merchants/#{@merchant_2.id}")
+  end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Merchants Show Page" do
+  before :each do
+    @merchant_1 = Merchant.create!(name: "Schroeder-Jerde")
+    @merchant_2 = Merchant.create!(name: "Klein, Rempel and Jones")
+    @merchant_3 = Merchant.create!(name: "Willms and Sons")
+  end
+
+  it "displays the name of the merchant" do
+    visit "/admin/merchants/#{@merchant_1.id}"
+    expect(page).to have_content(@merchant_1.name)
+    expect(page).to_not have_content(@merchant_2.name)
+    
+    visit "/admin/merchants/#{@merchant_2.id}"
+    expect(page).to have_content(@merchant_2.name)
+    expect(page).to_not have_content(@merchant_3.name)
+  end
+
+end


### PR DESCRIPTION
# Describe the changes below:
Added functionality which links Admin Merchants Index to the indv Show Pages
# Relevant user story:
As an admin,
When I click on the name of a merchant from the admin merchants index page (/admin/merchants),
Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
And I see the name of that merchant
# Before submitting, check the following:
- [x] Entire test suite is passing
- [100%] SimpleCov test percentage
