### PR TITLE
User story 26

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,4 +7,25 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def update
+    @merchant = Merchant.find(params[:id])
+    if @merchant.update(merchant_params)
+      redirect_to admin_merchant_path(@merchant)
+      flash[:notice] = "#{@merchant.name} has been successfully updated."
+    else
+      flash[:notice] = "Please enter a merchant name to continue."
+      render :edit
+    end
+  end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  private
+
+  def merchant_params
+    params.require(:merchant).permit(:name)
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="page-title">Admin Merchants Edit</div> 
+<br><br>
+<%= form_with(model: @merchant, url: admin_merchant_path(@merchant), local: true, data: { turbo: false }) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.submit "Submit" %>
+  <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,5 @@
 <div class="page-title">Admin Merchants Index</div> 
 
 <% @merchants.each do |merchant| %>
-<%= link_to merchant.name, admin_merchant_path(merchant) %>
+<p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,5 @@
 <div class="page-title">Admin Merchants Show</div> 
 
-<%= @merchant.name %>
+<p><%= @merchant.name %></p>
+
+<p><%= link_to "Update Merchant", edit_admin_merchant_path(@merchant) %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+  <% flash.each do |type, message| %>
+      <p><%= message %></p>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get "/", to: "dashboard#index"
-    resources :merchants, only: [:index, :show]
+    resources :merchants, only: [:index, :show, :edit, :update]
     resources :invoices, only: [:index, :show]
   end
 end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+
+RSpec.describe "Admin Merchants Edit Page" do
+  before :each do
+    @merchant_1 = Merchant.create!(name: "Schroeder-Jerde")
+    @merchant_2 = Merchant.create!(name: "Klein, Rempel and Jones")
+    @merchant_3 = Merchant.create!(name: "Willms and Sons")
+  end
+
+  describe "edit form" do
+    it "has an autopopulated name field with existing info" do
+      visit edit_admin_merchant_path(@merchant_1)
+      expect(page).to have_field("Name", with: @merchant_1.name)
+    end
+
+    it "will update the name upon submission which is reflected in a flash message" do
+      visit edit_admin_merchant_path(@merchant_1)
+      fill_in "Name", with: "Cocokind"
+      click_button "Submit"
+      
+      @merchant_1.reload
+      
+      expect(current_path).to eq(admin_merchant_path(@merchant_1))
+      
+      expect(page).to have_content("Cocokind")
+      expect(@merchant_1.name).to eq("Cocokind")
+      expect(page).to have_content("Cocokind has been successfully updated")
+    end
+
+    it "will function the same if no changes were made to the autopopulated field" do
+      visit edit_admin_merchant_path(@merchant_2)
+      fill_in "Name", with: "Klein, Rempel and Jones"
+      click_button "Submit"
+      
+      @merchant_2.reload
+      
+      expect(current_path).to eq(admin_merchant_path(@merchant_2))
+      
+      expect(page).to have_content("Klein, Rempel and Jones")
+      expect(@merchant_2.name).to eq("Klein, Rempel and Jones")
+      expect(page).to have_content("Klein, Rempel and Jones has been successfully updated")
+    end
+
+    it "will not allow submission with an empty text field" do
+      visit edit_admin_merchant_path(@merchant_3)
+      fill_in "Name", with: ""
+      click_button "Submit"
+
+      @merchant_3.reload
+
+      expect(page).to have_field("Name")
+      expect(page).to have_content("Please enter a merchant name to continue.")
+    end
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin Merchants Index Page" do
   end
 
   it "displays the name of each merchant in the system" do
-    visit "/admin/merchants"
+    visit admin_merchants_path
 
     expect(page).to have_content(@merchant_1.name)
     expect(page).to have_content(@merchant_2.name)
@@ -23,14 +23,14 @@ RSpec.describe "Admin Merchants Index Page" do
   end
 
   it "links to the merchant show page when you click the merchant's name" do
-    visit "/admin/merchants"
+    visit admin_merchants_path
 
     click_link(@merchant_1.name)
-    expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
+    expect(current_path).to eq(admin_merchant_path(@merchant_1))
 
-    visit "/admin/merchants"
+    visit admin_merchants_path
     
     click_link(@merchant_2.name)
-    expect(current_path).to eq("/admin/merchants/#{@merchant_2.id}")
+    expect(current_path).to eq(admin_merchant_path(@merchant_2))
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Admin Merchants Show Page" do
   end
 
   it "displays the name of the merchant" do
-    visit "/admin/merchants/#{@merchant_1.id}"
+    visit admin_merchant_path(@merchant_1)
     expect(page).to have_content(@merchant_1.name)
     expect(page).to_not have_content(@merchant_2.name)
     
-    visit "/admin/merchants/#{@merchant_2.id}"
+    visit admin_merchant_path(@merchant_2)
     expect(page).to have_content(@merchant_2.name)
     expect(page).to_not have_content(@merchant_3.name)
   end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe "Admin Merchants Show Page" do
     expect(page).to_not have_content(@merchant_3.name)
   end
 
+  it "links to a form to edit merchant attributes" do
+    visit admin_merchant_path(@merchant_1)
+    click_link "Update Merchant"
+
+    expect(current_path).to eq(edit_admin_merchant_path(@merchant_1))
+  end
+
 end


### PR DESCRIPTION
# Describe the changes below:
Add admin merchants edit form, including some extra flash messaging to help with user's sad path experience.

# Relevant user story:
User Story 26
As an admin,
When I visit a merchant's admin show page (/admin/merchants/:merchant_id)
Then I see a link to update the merchant's information.
When I click the link
Then I am taken to a page to edit this merchant
And I see a form filled in with the existing merchant attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the merchant's admin show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.

# Before submitting, check the following:
- [x] Entire test suite is passing
- [100%] SimpleCov test percentage

close #27 