### PR TITLE
User-story-16

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -170,28 +170,28 @@ ul {
   list-style-type: none;
 }
 
-.custom-table {
+.show-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.custom-table th,
-.custom-table td {
+.show-table th,
+.show-table td {
   border: 1px solid black;
   padding: 8px;
   text-align: center;
   vertical-align: center;
 }
 
-.custom-table th {
+.show-table th {
   background-color: #9E9E9E; /* Header Row Background Color */
   color: white; /* Text color for header cells */
 }
 
-.custom-table tr:nth-child(even) td {
+.show-table tr:nth-child(even) td {
   background-color: #E6E6E6; /* Lighter grey for even rows */
 }
 
-.custom-table tr:nth-child(odd) td {
+.show-table tr:nth-child(odd) td {
   background-color: #ffffffdb; /* Slightly darker than white for odd rows */
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -169,3 +169,29 @@ tr:nth-child(even) {
 ul {
   list-style-type: none;
 }
+
+.custom-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.custom-table th,
+.custom-table td {
+  border: 1px solid black;
+  padding: 8px;
+  text-align: center;
+  vertical-align: center;
+}
+
+.custom-table th {
+  background-color: #9E9E9E; /* Header Row Background Color */
+  color: white; /* Text color for header cells */
+}
+
+.custom-table tr:nth-child(even) td {
+  background-color: #E6E6E6; /* Lighter grey for even rows */
+}
+
+.custom-table tr:nth-child(odd) td {
+  background-color: #ffffffdb; /* Slightly darker than white for odd rows */
+}

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -3,3 +3,19 @@
 <p>Item Status: <%= @invoice.status %></p>
 <p>Created at: <%= format_date(@invoice.created_at) %></p>
 <p>Customer Name: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
+<table class="custom-table">
+  <tr>
+    <th>Item Name</th>
+    <th>Quantity</th>
+    <th>Unit Price</th>
+    <th>Status</th>
+  </tr>
+  <% @invoice.invoice_items.each do |invoice_item| %>
+    <tr>
+      <td><%= invoice_item.item.name %></td>
+      <td><%= invoice_item.quantity %></td>
+      <td><%= invoice_item.unit_price %></td>
+      <td><%= invoice_item.status %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -1,9 +1,9 @@
 <%= render partial: "shared/visitor_topper", locals: { invoices: true  } %>
 <div class="page-title">Invoice ID: <%= @invoice.id %></div>
-<p>Item Status: <%= @invoice.status %></p>
+<p>Invoice Status: <%= @invoice.status %></p>
 <p>Created at: <%= format_date(@invoice.created_at) %></p>
 <p>Customer Name: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
-<table class="custom-table">
+<table class="show-table">
   <tr>
     <th>Item Name</th>
     <th>Quantity</th>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "shared/visitor_topper", locals: { invoices: true  } %>
 <div class="page-title">Invoice ID: <%= @invoice.id %></div>
+<br>
 <p>Invoice Status: <%= @invoice.status %></p>
 <p>Created at: <%= format_date(@invoice.created_at) %></p>
 <p>Customer Name: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -14,7 +14,7 @@
     <tr>
       <td><%= invoice_item.item.name %></td>
       <td><%= invoice_item.quantity %></td>
-      <td><%= invoice_item.unit_price %></td>
+      <td><%= number_to_currency((invoice_item.unit_price / 100.0)) %></td>
       <td><%= invoice_item.status %></td>
     </tr>
   <% end %>

--- a/spec/features/merchant/merchant_invoices_index_spec.rb
+++ b/spec/features/merchant/merchant_invoices_index_spec.rb
@@ -3,13 +3,20 @@ require 'rails_helper'
 RSpec.describe 'Merchant Invoices Index' do
   before :each do
     @merchant1 = Merchant.create!(name: 'Hair Care')
+    @merchant2 = Merchant.create!(name: 'Jewelry')
+
     @customer1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
 
     @item1 = @merchant1.items.create!(name: 'Shampoo', description: 'This washes your hair', unit_price: 10,
                                       status: 0)
+    @item2 = @merchant2.items.create!(name: 'Conditioner', description: 'This makes your hair shiny', unit_price: 20,
+                                      status: 0)
+
     @invoice1 = @customer1.invoices.create!(status: 1)
+    @invoice2 = @customer1.invoices.create!(status: 1)
 
     InvoiceItem.create!(item: @item1, invoice: @invoice1, quantity: 1, unit_price: 10, status: 0)
+    InvoiceItem.create!(item: @item2, invoice: @invoice2, quantity: 1, unit_price: 20, status: 0)
   end
 
   # User Story 14 Testing Begins
@@ -30,58 +37,6 @@ RSpec.describe 'Merchant Invoices Index' do
     within "#invoice-#{@invoice1.id}" do
       expect(page).to have_link(@invoice1.id.to_s, href: merchant_invoice_path(@merchant1, @invoice1))
     end
-  end
-  # User Story 14 Testing End
-
-  # User Story 15 Testing Begins
-
-  # As a merchant
-  # When I visit my merchant's invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
-  # Then I see information related to that invoice including:
-
-  # Invoice id
-  # Invoice status
-  # Invoice created_at date in the format "Monday, July 18, 2019"
-  # Customer first and last name
-
-  it 'displays the invoice id and status on the merchants show page' do
-    visit merchant_invoice_path(@merchant1, @invoice1)
-
-    expect(page).to have_content(@invoice1.id)
-    expect(page).to have_content(@invoice1.status)
-  end
-
-  it 'displays the invoice created_at date in the format "Monday, July 18, 2019"' do
-    visit merchant_invoice_path(@merchant1, @invoice1)
-
-    expect(page).to have_content(@invoice1.created_at.strftime('%A, %B %d, %Y'))
-  end
-
-  it 'displays the customer first and last name' do
-    visit merchant_invoice_path(@merchant1, @invoice1)
-
-    expect(page).to have_content(@customer1.first_name)
-    # User Story 15 Testing End
-  end
-
-  # User Story 16 Testing Begins
-
-  # As a merchant
-  # When I visit my merchant invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
-  # Then I see all of my items on the invoice including:
-
-  # Item name
-  # The quantity of the item ordered
-  # The price the Item sold for
-  # The Invoice Item status
-  # And I do not see any information related to Items for other merchants
-
-  it 'displays item name, quantity, price, and invoice item status for this merchant only' do
-    visit merchant_invoice_path(@merchant1, @invoice1)
-
-    expect(page).to have_content(@item1.name)
-    expect(page).to have_content(@item1.quantity)
-    expect(page).to have_content(@item1.unit_price)
-    expect(page).to have_content(@item1.status)
+    # User Story 14 Testing End
   end
 end

--- a/spec/features/merchant/merchant_invoices_index_spec.rb
+++ b/spec/features/merchant/merchant_invoices_index_spec.rb
@@ -61,5 +61,27 @@ RSpec.describe 'Merchant Invoices Index' do
     visit merchant_invoice_path(@merchant1, @invoice1)
 
     expect(page).to have_content(@customer1.first_name)
+    # User Story 15 Testing End
+  end
+
+  # User Story 16 Testing Begins
+
+  # As a merchant
+  # When I visit my merchant invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
+  # Then I see all of my items on the invoice including:
+
+  # Item name
+  # The quantity of the item ordered
+  # The price the Item sold for
+  # The Invoice Item status
+  # And I do not see any information related to Items for other merchants
+
+  it 'displays item name, quantity, price, and invoice item status for this merchant only' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    expect(page).to have_content(@item1.name)
+    expect(page).to have_content(@item1.quantity)
+    expect(page).to have_content(@item1.unit_price)
+    expect(page).to have_content(@item1.status)
   end
 end

--- a/spec/features/merchant/merchant_invoices_show_spec.rb
+++ b/spec/features/merchant/merchant_invoices_show_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Invoices Index' do
+  include ActionView::Helpers::NumberHelper
+
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @merchant2 = Merchant.create!(name: 'Jewelry')
+
+    @customer1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+
+    @item1 = @merchant1.items.create!(name: 'Shampoo', description: 'This washes your hair', unit_price: 10,
+                                      status: 0)
+    @item2 = @merchant2.items.create!(name: 'Conditioner', description: 'This makes your hair shiny', unit_price: 20,
+                                      status: 0)
+
+    @invoice1 = @customer1.invoices.create!(status: 1)
+    @invoice2 = @customer1.invoices.create!(status: 1)
+
+    InvoiceItem.create!(item: @item1, invoice: @invoice1, quantity: 1, unit_price: 10, status: 0)
+    InvoiceItem.create!(item: @item2, invoice: @invoice2, quantity: 1, unit_price: 20, status: 0)
+  end
+
+  # User Story 15 Testing Begins
+
+  # As a merchant
+  # When I visit my merchant's invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
+  # Then I see information related to that invoice including:
+
+  # Invoice id
+  # Invoice status
+  # Invoice created_at date in the format "Monday, July 18, 2019"
+  # Customer first and last name
+
+  it 'displays the invoice id and status on the merchants show page' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    expect(page).to have_content(@invoice1.id)
+    expect(page).to have_content(@invoice1.status)
+  end
+
+  it 'displays the invoice created_at date in the format "Monday, July 18, 2019"' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    expect(page).to have_content(@invoice1.created_at.strftime('%A, %B %d, %Y'))
+  end
+
+  it 'displays the customer first and last name' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    expect(page).to have_content(@customer1.first_name)
+    # User Story 15 Testing End
+  end
+
+  # User Story 16 Testing Begins
+
+  # As a merchant
+  # When I visit my merchant invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
+  # Then I see all of my items on the invoice including:
+
+  # Item name
+  # The quantity of the item ordered
+  # The price the Item sold for
+  # The Invoice Item status
+  # And I do not see any information related to Items for other merchants
+
+  it 'displays item name, quantity, price, and invoice item status for this merchant' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    @invoice1.invoice_items.each do |invoice_item|
+      expect(page).to have_content(invoice_item.item.name)
+      expect(page).to have_content(invoice_item.quantity)
+      expect(page).to have_content(number_to_currency(invoice_item.unit_price / 100.0))
+      expect(page).to have_content(invoice_item.status)
+    end
+  end
+
+  it 'does not display any information related to items for other merchants' do
+    visit merchant_invoice_path(@merchant1, @invoice1)
+
+    @invoice1.invoice_items.each do |_invoice_item|
+      expect(page).to_not have_content(@item2.name)
+      expect(page).to_not have_content(@item2.description)
+      expect(page).to_not have_content(number_to_currency(@item2.unit_price / 100.0))
+      expect(page).to_not have_content(@item2.status)
+    end
+  end
+end


### PR DESCRIPTION
# Describe the changes below:
- Adds show-table CSS to application.css file.
- Adds table with invoice item information to invoices show view page.
- Creates merchant_invoices_show_spec file and moves show tests from merchant_invoices_index_spec page into it.
- Also adds tests for this user story (16) into the new file.

# Relevant user story:
s a merchant
When I visit my merchant invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
Then I see all of my items on the invoice including:

Item name
The quantity of the item ordered
The price the Item sold for
The Invoice Item status
And I do not see any information related to Items for other merchants


# Specific feedback requests? Include file name and line:

# Before submitting, check the following:
- [X] Entire test suite is passing
- [X] SimpleCov test percentage (99.56%)

# Note any co-authors / anything else you'd like to add: