### PR TITLE
User story 36

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,17 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    invoice.update(invoice_params)
+    invoice.save
+
+    redirect_to admin_invoice_path(invoice)
+  end
+
+private
+  def invoice_params
+    params.permit(:status)
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,7 +2,13 @@
 <h3 class="full-length-header"> Invoice #<%= @invoice.id  %></h3>
 
 <div id="invoice-customer-info">
-  <p>Status: <%= @invoice.status.capitalize %></p>
+  <%= form_with url: admin_invoice_path(@invoice), method: :patch, local: true do |form| %>
+    <p>
+      <%= form.label :status, "Status:" %>
+      <%= form.select :status, [["In Progress", "in progress"],["Cancelled", "cancelled"],["Completed", "completed"]], selected: @invoice.status %>
+      <%= form.submit "Update Invoice" %>
+    </p>
+  <% end %>
   <p>Created on: <%= @invoice.created_at.strftime('%A, %e %b %Y') %></p>
   <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue / 100.0)) %></p>
 

--- a/app/views/shared/_admin_topper.html.erb
+++ b/app/views/shared/_admin_topper.html.erb
@@ -23,4 +23,3 @@
     </ul>
   </nav>
 </div>
-<div class="seperator"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboard#index"
     resources :merchants, only: [:index, :show, :edit, :update]
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Invoices Index Page', type: :feature do
+  describe "When I visit the admin Invoices index (/admin/invoices)" do
+    before :each do
+      @joey = Customer.create!(first_name: 'Joey', last_name: 'Ondricka')
+      @Cecelia = Customer.create!(first_name: 'Cecelia', last_name: 'Osinski')
+      @Mariah = Customer.create!(first_name: 'Mariah', last_name: 'Toy')
+
+      @invoice_1 = @joey.invoices.create!()
+      @invoice_2 = @joey.invoices.create!()
+      @invoice_3 = @Cecelia.invoices.create!()
+      @invoice_4 = @Mariah.invoices.create!()
+
+      @merchant_1 = Merchant.create!(name: "Schroeder-Jerde")
+      @merchant_2 = Merchant.create!(name: "Klein, Rempel and Jones")
+
+      @item_1 = @merchant_1.items.create!(name: "Qui Esse", description: "Nihil autem sit odio inventore deleniti. Est laudantium ratione distincti", unit_price: 75107)
+      @item_2 = @merchant_1.items.create!(name: "Autem Minima", description: "Sunt officia eum qui molestiae. Nesciunt quidem cupiditate reiciendis est commodi non.", unit_price: 67076)
+      @item_3 = @merchant_1.items.create!(name: "Ea Voluptatum", description: "Voluptate aut labore qui illum tempore eius. Corrupti cum et rerum. Enim illum labore voluptatem dicta consequatur. Consequatur sunt consequuntur ut officiis.", unit_price: 32301)
+      @item_4 = @merchant_1.items.create!(name: "Nemo Facere", description: "Numquam officiis reprehenderit eum ratione neque tenetur. Officia aut repudiandae eum at ipsum doloribus. Iure minus itaque similique. Ratione dicta alias", unit_price: 15925)
+      @item_5 = @merchant_2.items.create!(name: "Expedita Aliquam", description: "Reprehenderit est officiis cupiditate quia eos. Voluptatem illum reprehenderit quo vel eligendi. Et eum omnis id ut aliquid veniam.", unit_price: 31163)
+      @item_6 = @merchant_2.items.create!(name: "Provident At", description: "Reiciendis sed aperiam culpa animi laudantium. Eligendi veritatis sint dolorem asperiores. Earum alias illum eos non rerum.", unit_price: 22582)
+      @item_7 = @merchant_2.items.create!(name: "Expedita Fuga", description: "Voluptatibus omnis quo recusandae distinctio voluptatem quibusdam et. Voluptas odio accusamus delectus sunt quia. Non atque rerum vitae officia odit.", unit_price: 42629)
+
+      InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 5, unit_price: 70000, status: 0)
+      InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, quantity: 6, unit_price: 69000, status: 0)
+      InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_2.id, quantity: 5, unit_price: 32000, status: 0)
+      InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_3.id, quantity: 5, unit_price: 16000, status: 0)
+      InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_3.id, quantity: 5, unit_price: 19000, status: 0)
+      InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_4.id, quantity: 7, unit_price: 30000, status: 0)
+      InvoiceItem.create!(item_id: @item_6.id, invoice_id: @invoice_4.id, quantity: 3, unit_price: 20000, status: 0)
+      InvoiceItem.create!(item_id: @item_7.id, invoice_id: @invoice_4.id, quantity: 7, unit_price: 45000, status: 0)
+
+      visit admin_invoices_path
+    end
+
+    it "Has a list of all Invoice ids in the system" do
+      expect(page).to have_css(".admin-invoices")
+      
+      expect(page).to have_content(@invoice_1.id, count: 1)
+      expect(page).to have_content(@invoice_2.id, count: 1)
+      expect(page).to have_content(@invoice_3.id, count: 1)
+      expect(page).to have_content(@invoice_4.id, count: 1)
+    end
+
+    it "Each id links to the admin invoice show page" do
+      expect(page).to have_link("Invoice ##{@invoice_1.id}", count: 1)
+      expect(page).to have_link("Invoice ##{@invoice_2.id}", count: 1)
+      expect(page).to have_link("Invoice ##{@invoice_3.id}", count: 1)
+      expect(page).to have_link("Invoice ##{@invoice_4.id}", count: 1)
+    end
+  end
+end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe 'Admin Invoice Show Page', type: :feature do
 
       it "shows the invoice's status" do
         within("#invoice-customer-info") do
-          expect(page).to have_content(@invoice_1.status.capitalize, count: 1)
-          expect(page).to_not have_content(@invoice_2.status.capitalize)
+          expect(page).to have_content("Status: In Progress", count: 1)
         end
       end
 
@@ -108,6 +107,46 @@ RSpec.describe 'Admin Invoice Show Page', type: :feature do
     describe "Then I see the total revenue that will be generated from this invoice." do
       it "shows the total revenue that will be generated from the invoice" do
         expect(page).to have_content("Total Revenue: $7,640.00")
+      end
+    end
+
+    describe "The invoice status is a select field" do
+      it "shows selected initially as the invoice's current status" do
+        within("#invoice-customer-info") do
+          expect(page).to have_select :status, selected: "In Progress"
+        end
+      end
+
+      it "when clicked, can select a new status for the Invoice" do
+        within("#invoice-customer-info") do
+          expect(page).to have_select :status, with_options: ["In Progress", "Cancelled", "Completed"]
+        end
+      end
+
+      it "has a button next to the select field 'Update Invoice'" do
+        within("#invoice-customer-info") do
+          expect(page).to have_button "Update Invoice"
+        end
+      end
+
+      it "once 'Update Invoice Status' is clicked, it redirects to the invoice page" do 
+        within("#invoice-customer-info") do
+          select "Cancelled", from: :status
+          click_button "Update Invoice"
+        end
+
+        expect(current_path).to eq(admin_invoice_path(@invoice_1))
+      end
+
+      it "when redirected, shows the updated invoice status" do
+        expect(page).to have_select :status, selected: "In Progress"
+
+        within("#invoice-customer-info") do
+          select "Cancelled", from: :status
+          click_button "Update Invoice"
+        end
+
+        expect(page).to have_select :status, selected: "Cancelled"
       end
     end
   end


### PR DESCRIPTION
# Describe the changes below:
- Removes erroneous div line causing view issues in admin page topper partial
- Adds missing Admin Invoice Index spec file
- Add tests, route, controller action, and view for updating an Admin's Invoice's Status.
# Relevant user story:
```
36. Admin Invoice Show Page: Update Invoice Status
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated

```

# Before submitting, check the following:
- [x] Entire test suite is passing
- [98% - See Note Below] SimpleCov test percentage

# Note any co-authors / anything else you'd like to add:

SimpleCov shows a reduction in coverage caused by an untested part of the `app/controllers/items_controller.rb`. Specifically the `render "edit"` line.  
CC: @MatthewTLim 