### PR TITLE
User story 19

### DIFF
--- a/app/views/shared/_admin_topper.html.erb
+++ b/app/views/shared/_admin_topper.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Little Esty Shop", root_path, style: "text-decoration: none; color: black;" %>
 </header>
 <div class="page-topper">
-  <h2 id="merchant-admin-name"><%= @merchant_name %></h2>
+  <h2 id="merchant-admin-name">Admin Dashboard</h2>
   <nav id="nav_bar">
     <ul>
       <% if local_assigns[:dashboard] %>
@@ -23,4 +23,3 @@
     </ul>
   </nav>
 </div>
-<div class="seperator"></div>

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Dashboard (index)', type: :feature do
+  describe 'When I visit the admin dashboard (/admin)' do
+    before :each do
+      visit admin_path
+    end
+    
+    it "Has a header indicating that I am on the admin dashboard" do 
+      expect(page).to have_content("Admin Dashboard", count: 1)
+    end
+  end
+end


### PR DESCRIPTION
# Describe the changes below:
- Fixes an accidental change of Admin Dashboard header on the admin page topper partial
- Adds test for Admin Dashboard header
# Relevant user story:
```
19. Admin Dashboard
As an admin,
When I visit the admin dashboard (/admin)
Then I see a header indicating that I am on the admin dashboard
```

# Before submitting, check the following:
- [x] Entire test suite is passing
- [100%] SimpleCov test percentage