### PR TITLE
User story 27

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -11,11 +11,14 @@ class Admin::MerchantsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:id])
     if @merchant.update(merchant_params)
-      redirect_to admin_merchant_path(@merchant)
-      flash[:notice] = "#{@merchant.name} has been successfully updated."
-    else
-      flash[:notice] = "Please enter a merchant name to continue."
-      render :edit
+      if merchant_params[:status].present?
+        redirect_to admin_merchants_path
+      else redirect_to admin_merchant_path(@merchant)
+        flash[:notice] = "#{@merchant.name} has been successfully updated."
+      end
+      else
+        flash[:notice] = "Please enter a merchant name to continue."
+        render :edit
     end
   end
 
@@ -26,6 +29,6 @@ class Admin::MerchantsController < ApplicationController
   private
 
   def merchant_params
-    params.require(:merchant).permit(:name)
+    params.require(:merchant).permit(:name, :status)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,9 @@
 class Merchant < ApplicationRecord
   has_many :items
 
-  validates_presence_of :name
+  validates_presence_of :name, :status
+
+  enum :status, { "enabled" => 0, "disabled" => 1 }
 
   def invoices
     Invoice.joins(items: :merchant).where(items: { merchant: self }).distinct

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="page-title">Admin Merchants Edit</div> 
 <br><br>
-<%= form_with(model: @merchant, url: admin_merchant_path(@merchant), local: true, data: { turbo: false }) do |f| %>
+<%= form_with(model: @merchant, url: admin_merchant_path(@merchant), local: true, data: { turbo: false }, params: { merchant: :name}) do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
   <%= f.submit "Submit" %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -4,7 +4,7 @@
 <p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
 <% if merchant.status == "enabled" %>
   <%= button_to "Disable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "disabled"}} %>
-<% else merchant.status == "enabled" %>
+<% else %>
   <%= button_to "Enable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "enabled"}} %>
   <% end %>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,4 +2,9 @@
 
 <% @merchants.each do |merchant| %>
 <p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
+<% if merchant.status == "enabled" %>
+  <%= button_to "Disable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "disabled"}} %>
+<% else merchant.status == "enabled" %>
+  <%= button_to "Enable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "enabled"}} %>
+  <% end %>
 <% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -15,4 +15,3 @@
 <% end %>
 
 
-# try without method patch

--- a/db/migrate/20230728223205_add.rb
+++ b/db/migrate/20230728223205_add.rb
@@ -1,0 +1,5 @@
+class Add < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :status, :enum, enum_type: :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_220342) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_223205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_220342) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "Admin Merchants Index Page" do
 
       expect(@merchant_1.status).to eq("enabled")
       click_button "Disable #{@merchant_1.name}"
-
       @merchant_1.reload
       expect(@merchant_1.status).to eq("disabled")
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -33,4 +33,44 @@ RSpec.describe "Admin Merchants Index Page" do
     click_link(@merchant_2.name)
     expect(current_path).to eq(admin_merchant_path(@merchant_2))
   end
+
+  describe "disable/enable merchants button" do
+    it "disables or enables the merchant when clicked" do
+      visit admin_merchants_path
+
+      expect(@merchant_1.status).to eq("enabled")
+      click_button "Disable #{@merchant_1.name}"
+
+      @merchant_1.reload
+      expect(@merchant_1.status).to eq("disabled")
+
+
+      visit admin_merchants_path
+
+      expect(@merchant_2.status).to eq("enabled")
+      click_button "Disable #{@merchant_2.name}"
+
+      @merchant_2.reload
+      expect(@merchant_2.status).to eq("disabled")
+    end
+
+    it "displays the updated merchant status on once clicked" do
+      visit admin_merchants_path
+      click_button "Disable #{@merchant_1.name}"
+      @merchant_1.reload
+      
+      expect(page).to have_button("Enable #{@merchant_1.name}")
+      
+      click_button "Enable #{@merchant_1.name}"
+      @merchant_1.reload
+      
+      expect(page).to have_button("Disable #{@merchant_1.name}")
+    end
+  end
 end
+
+# When I visit the admin merchants index (/admin/merchants)
+# Then next to each merchant name I see a button to disable or enable that merchant.
+# When I click this button
+# Then I am redirected back to the admin merchants index
+# And I see that the merchant's status has changed

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -68,9 +68,3 @@ RSpec.describe "Admin Merchants Index Page" do
     end
   end
 end
-
-# When I visit the admin merchants index (/admin/merchants)
-# Then next to each merchant name I see a button to disable or enable that merchant.
-# When I click this button
-# Then I am redirected back to the admin merchants index
-# And I see that the merchant's status has changed

--- a/spec/features/merchant_spec.rb
+++ b/spec/features/merchant_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Merchant do
                     click_link "Edit #{@item_1.name}"
 
                     expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}/edit")
-                    save_and_open_page
+                    
                     expect(page).to have_field("Name", with: @item_1.name)
                     expect(page).to have_field("Description", with: @item_1.description)
                     expect(page).to have_field("Unit price", with: @item_1.unit_price)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Merchant, type: :model do
 
   describe 'Validations' do
     it { should validate_presence_of :name }
+    it { should validate_presence_of :status }
+    it { should define_enum_for(:status).with_values(["enabled", "disabled"]) }
+
   end
 
   describe 'Instance Methods' do


### PR DESCRIPTION
# Describe the changes below:
Add migration of status column to merchants table, add testing and functionality for user story 27.
# Relevant user story:
As an admin,
When I visit the admin merchants index (/admin/merchants)
Then next to each merchant name I see a button to disable or enable that merchant.
When I click this button
Then I am redirected back to the admin merchants index
And I see that the merchant's status has changed

# Before submitting, check the following:
- [x] Entire test suite is passing
- [99.85%] SimpleCov test percentage

close #28