### PR TITLE
User story 28

### DIFF
--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,10 +1,24 @@
 <%= render partial: "shared/admin_topper", locals: { merchants: true  } %>
 
-<% @merchants.each do |merchant| %>
-<p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
-<% if merchant.status == "enabled" %>
-  <%= button_to "Disable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "disabled"}} %>
-<% else %>
-  <%= button_to "Enable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "enabled"}} %>
+<div class="page-title">Admin Merchants Index</div> 
+
+
+<div id="enabled-merchants">
+  <h3>Enabled Merchants</h3>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "enabled" %>
+    <%= link_to merchant.name, admin_merchant_path(merchant) %>
+    <%= button_to "Disable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "disabled"}} %>
+    <% end %>
   <% end %>
-<% end %>
+</div>
+
+<div id="disabled-merchants">
+  <h3>Disabled Merchants</h3>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "disabled" %>
+    <%= link_to merchant.name, admin_merchant_path(merchant) %>
+    <%= button_to "Enable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: { merchant: { status: "enabled"}} %>
+    <% end %>
+  <% end %>
+</div>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -66,4 +66,28 @@ RSpec.describe "Admin Merchants Index Page" do
       expect(page).to have_button("Disable #{@merchant_1.name}")
     end
   end
+
+  it "displays the enabled and disabled merchants in two separate sections" do
+    visit admin_merchants_path
+    click_button "Disable #{@merchant_3.name}"
+    click_button "Disable #{@merchant_5.name}"
+    @merchant_3.reload
+    @merchant_5.reload
+
+    expect("Enabled Merchants").to appear_before("Disabled Merchants")
+
+    save_and_open_page
+    within("#enabled-merchants") do
+      expect(page).to have_content(@merchant_1.name)
+      expect(page).to have_content(@merchant_2.name)
+      expect(page).to have_content(@merchant_4.name)
+      expect(page).to have_content(@merchant_6.name)
+      expect(page).to_not have_content(@merchant_3.name)
+    end
+    within("#disabled-merchants") do
+    expect(page).to have_content(@merchant_3.name)
+    expect(page).to have_content(@merchant_5.name)
+    expect(page).to_not have_content(@merchant_1.name)
+    end
+  end
 end


### PR DESCRIPTION
# Describe the changes below:
Add testing and display logic to admin merchant index page for US 28.
# Relevant user story:
As an admin,
When I visit the admin merchants index (/admin/merchants)
Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
And I see that each Merchant is listed in the appropriate section
# Before submitting, check the following:
- [x] Entire test suite is passing
- [99.85%] SimpleCov test percentage

close #29 