### PR TITLE
Add-merchant-name-to-merchant-pages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -240,3 +240,17 @@ ul {
   height: 30px;
   font-family: sans-serif;
 }
+
+.merchant-navbar-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#merchant-name {
+  margin-left: 20px; /* adjust as needed */
+}
+
+#nav_bar {
+  margin-right: 20px; /* adjust as needed */
+}

--- a/app/views/shared/_visitor_topper.html.erb
+++ b/app/views/shared/_visitor_topper.html.erb
@@ -2,25 +2,27 @@
   <%= link_to "Little Esty Shop", root_path, style: "text-decoration: none; color: black;" %>
 </header>
 <div class="page-topper">
-  <h2 id="merchant-name"><%= @merchant_name %></h2>
-  <nav id="nav_bar">
-    <ul>
-      <% if local_assigns[:dashboard] %>
-        <li class="current-menu-item"><%= link_to "Dashboard", merchant_dashboard_index_path %></li>
-      <% else %>
-        <li><%= link_to "Dashboard", merchant_dashboard_index_path %></li>
-      <% end %>
-      <% if local_assigns[:items] %>
-        <li class="current-menu-item"><%= link_to "My Items", merchant_items_path %></li>
-      <% else %>
-        <li><%= link_to "My Items", merchant_items_path %></li>
-      <% end %>
-      <% if local_assigns[:invoices] %>
-        <li class="current-menu-item"><%= link_to "My Invoices", merchant_invoices_path %></li>
-      <% else %>
-        <li><%= link_to "My Invoices", merchant_invoices_path %></li>
-      <% end %>
-    </ul>
-  </nav>
+  <div class="merchant-navbar-wrapper">
+    <h2 id="merchant-name"><%= @merchant.name %></h2>
+    <nav id="nav_bar">
+      <ul>
+        <% if local_assigns[:dashboard] %>
+          <li class="current-menu-item"><%= link_to "Dashboard", merchant_dashboard_index_path %></li>
+        <% else %>
+          <li><%= link_to "Dashboard", merchant_dashboard_index_path %></li>
+        <% end %>
+        <% if local_assigns[:items] %>
+          <li class="current-menu-item"><%= link_to "My Items", merchant_items_path %></li>
+        <% else %>
+          <li><%= link_to "My Items", merchant_items_path %></li>
+        <% end %>
+        <% if local_assigns[:invoices] %>
+          <li class="current-menu-item"><%= link_to "My Invoices", merchant_invoices_path %></li>
+        <% else %>
+          <li><%= link_to "My Invoices", merchant_invoices_path %></li>
+        <% end %>
+      </ul>
+    </nav>
+  </div>
 </div>
 <div class="seperator"></div>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe "Admin Merchants Index Page" do
 
     expect("Enabled Merchants").to appear_before("Disabled Merchants")
 
-    save_and_open_page
     within("#enabled-merchants") do
       expect(page).to have_content(@merchant_1.name)
       expect(page).to have_content(@merchant_2.name)


### PR DESCRIPTION
# Describe the changes below:
- Adds merchant name in visitor partial header.
- Adds CSS for styling of merchant name.
- Removes save_and_open command from admin/merchants/index_spec

# Relevant user story:
Related to merchant wireframes not a specific user story.

# Specific feedback requests? Include file name and line:

# Before submitting, check the following:
- [X] Entire test suite is passing
- [X] SimpleCov test percentage (99.78%)

# Note any co-authors / anything else you'd like to add: