### PR TITLE
User story 22

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -75,6 +75,41 @@ nav a:hover {
   text-align: center;
   padding: 5px;
   background-color: #D8DAD3;
+  margin-bottom: 40px;
+}
+
+.left-half-div {
+  display: inline;
+  width: 45%;
+  float: left;
+}
+
+.right-half-div {
+  display: inline;
+  width: 45%;
+  float: right;
+}
+
+#admin-top-5-customers li {
+  font-size: 20px;
+  padding: 5px 0px;
+  margin-top: 10px;
+  margin-left: 40px;
+}
+
+#admin-incomplete-invoices a {
+  font-size: 20px;
+  padding: 5px 0px;
+  margin-top: 10px;
+  margin-left: 50px;
+}
+#admin-incomplete-invoices a {
+  text-decoration: none;
+}
+
+#admin-incomplete-invoices a:hover {
+  text-decoration: underline;
+  color: orange;
 }
 
 .right-half-div {

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -11,4 +11,8 @@ class Customer < ApplicationRecord
       .order("count DESC")
       .limit(5)
   end
+
+  def self.all_incomplete_invoices
+    Invoice.where(status: "in progress").order(:id).pluck(:id)
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,12 @@
 <%= render partial: "shared/admin_topper", locals: { dashboard: true  } %>
 
+<div class="left-half-div" id="admin-incomplete-invoices">
+  <h3 class="half-header"> Incomplete Invoices </h3>
+  <% @customers.all_incomplete_invoices.each do |invoice| %>
+    <p><%= link_to "Invoice # #{invoice}", admin_invoice_path(invoice) %></p>
+  <% end %>
+</div>
+
 <div class="right-half-div" id="admin-top-5-customers">
   <h3 class="half-header"> Top Customers </h3>
   <ol>

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe 'Admin Dashboard (index)', type: :feature do
 
       @invoice_1 = @joey.invoices.create!()
       @invoice_2 = @joey.invoices.create!(status: 2)
-      @invoice_3 = @cecelia.invoices.create!()
+      @invoice_3 = @cecelia.invoices.create!(status: 1)
       @invoice_4 = @mariah.invoices.create!()
       @invoice_5 = @leanne.invoices.create!()
-      @invoice_6 = @sylvester.invoices.create!()
+      @invoice_6 = @sylvester.invoices.create!(status: 1)
       @invoice_7 = @heber.invoices.create!()
       @invoice_8 = @dejon.invoices.create!()
       @invoice_9 = @logan.invoices.create!()
@@ -117,6 +117,39 @@ RSpec.describe 'Admin Dashboard (index)', type: :feature do
         expect(page).to have_content("Cecelia Osinski - 2 purchases", count: 1)
         expect(page).to have_content("Leanne Kuhn - 2 purchases", count: 1)
       end
+   end
+
+   describe "Invomplete Invoices" do
+    it "has a section for listing all the 'Incomplete Invoices'" do
+      expect(page).to have_css(".left-half-div")
+      expect(page).to have_content("Incomplete Invoices", count: 1)
+    end
+
+    it "lists the ids  of invoices with items not shipped" do
+      expect(page).to_not have_content(@invoice_2.id, count: 1)
+      expect(page).to_not have_content(@invoice_3.id, count: 1)
+      expect(page).to_not have_content(@invoice_6.id, count: 1)
+
+      expect(page).to have_content(@invoice_1.id, count: 1)
+      expect(page).to have_content(@invoice_4.id, count: 1)
+      expect(page).to have_content(@invoice_5.id, count: 1)
+      expect(page).to have_content(@invoice_7.id, count: 1)
+      expect(page).to have_content(@invoice_8.id, count: 1)
+      expect(page).to have_content(@invoice_9.id, count: 1)
+    end
+
+    it "links to the show page for each invoices" do
+      expect(page).to_not have_link("Invoice # #{@invoice_2.id}", count: 1)
+      expect(page).to_not have_link("Invoice # #{@invoice_3.id}", count: 1)
+      expect(page).to_not have_link("Invoice # #{@invoice_6.id}", count: 1)
+
+      expect(page).to have_link("Invoice # #{@invoice_1.id}", count: 1)
+      expect(page).to have_link("Invoice # #{@invoice_4.id}", count: 1)
+      expect(page).to have_link("Invoice # #{@invoice_5.id}", count: 1)
+      expect(page).to have_link("Invoice # #{@invoice_7.id}", count: 1)
+      expect(page).to have_link("Invoice # #{@invoice_8.id}", count: 1)
+      expect(page).to have_link("Invoice # #{@invoice_9.id}", count: 1)
+    end
    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Admin Invoice Show Page', type: :feature do
     describe "I see information related to that invoice" do
       it "shows the invoice's ID" do
           expect(page).to have_content("Invoice ##{@invoice_1.id}", count: 1)
-          expect(page).to_not have_content(@invoice_2.id)
+          expect(page).to_not have_content("Invoice ##{@invoice_2.id}")
       end
 
       it "shows the invoice's status" do
@@ -49,7 +49,7 @@ RSpec.describe 'Admin Invoice Show Page', type: :feature do
 
       it "shows the invoice's created_at date in the format 'Monday, July 18, 2019'" do
         within("#invoice-customer-info") do
-          expect(page).to have_content(Date.today.strftime('%A, %e %b %Y'), count: 1)
+          expect(page).to have_content(@invoice_1.created_at.strftime('%A, %e %b %Y'), count: 1)
         end
       end
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Admin Merchants Index Page" do
 
     expect("Enabled Merchants").to appear_before("Disabled Merchants")
 
-    save_and_open_page
+   
     within("#enabled-merchants") do
       expect(page).to have_content(@merchant_1.name)
       expect(page).to have_content(@merchant_2.name)

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Customer, type: :model do
 
       @invoice_1 = @joey.invoices.create!()
       @invoice_2 = @joey.invoices.create!(status: 2)
-      @invoice_3 = @cecelia.invoices.create!()
+      @invoice_3 = @cecelia.invoices.create!(status: 1)
       @invoice_4 = @mariah.invoices.create!()
       @invoice_5 = @leanne.invoices.create!()
-      @invoice_6 = @sylvester.invoices.create!()
+      @invoice_6 = @sylvester.invoices.create!(status: 1)
       @invoice_7 = @heber.invoices.create!()
       @invoice_8 = @dejon.invoices.create!()
       @invoice_9 = @logan.invoices.create!()
@@ -108,6 +108,12 @@ RSpec.describe Customer, type: :model do
         expect(expected_results[3].count).to eq(2)
         expect(expected_results[4].count).to eq(2)
       end
+    end
+
+    it "Can find all incomplete Invoice IDs (not shipped or completed)" do
+      expected = [@invoice_1.id, @invoice_4.id, @invoice_5.id, @invoice_7.id, @invoice_8.id, @invoice_9.id]
+      
+      expect(Customer.all_incomplete_invoices).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
# Describe the changes below:
- Fixes admin invoice show page test that sometimes fails due to dynamic nature of IDs
- Adds test and model method #all_incomplete_invoices to Customer model for use on Admin Dashboard
- Adds tests and view for showcasing incomplete invoices on the Admin Dashboard

# Relevant user story:
```
As an admin,
When I visit the admin dashboard (/admin)
Then I see a section for "Incomplete Invoices"
In that section I see a list of the ids of all invoices
That have items that have not yet been shipped
And each invoice id links to that invoice's admin show page
```

# Before submitting, check the following:
- [x] Entire test suite is passing
- [99.78%] SimpleCov test percentage